### PR TITLE
Add capacitor-shamir

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,6 +227,7 @@ Independents plugins are listed here.
 - [Screenshot](https://github.com/ludufre/capacitor-screenshot) - Take a screenshot of the current view.
 - [Send intent](https://github.com/tavosansal/capacitor-plugin-send-intent) - Expose a listener in your JavaScript application for when another application sends data to your Capacitor application via the Android share menu or share sheet.
 - [Sentry](https://github.com/getsentry/sentry-capacitor) - Add Sentry error tracking and performance monitoring for Capacitor apps.
+- [Shamir](https://github.com/vault12/capacitor-shamir) - Shamir's Secret Sharing cryptographic algorithm.
 - [Stripe terminal](https://github.com/eventOneHQ/capacitor-stripe-terminal) - Stripe Terminal Plugin for Capacitor.
 - [Sprig](https://github.com/crabbydavis/sprig) - All-in-one  product research platform.
 - [Square Payments](https://github.com/jbrown0824/capacitor-square-payments) - Enable Square Payments for Capacitor.


### PR DESCRIPTION
Hi! I'd like to suggest a new plugin we've just open-sourced at @vault12: `capacitor-shamir`. It's a native Capacitor plugin for _Shamir's Secret Sharing_. It may be useful for developers building secure storage, crypto wallets, or threshold-authentication features. It's production-ready, fully documented, and actively maintained.

Thanks for maintaining this great list!