### PR TITLE
Add Native Audio Player plugin to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ Independents plugins are listed here.
 - [Intent](https://github.com/IT-MikeS/capacitor-intents) - Supports multiple broadcast receiving of intents, and sending out BroadcastIntents in Android.
 - [Jitsi](https://github.com/calvinckho/capacitor-jitsi-meet) - Make video calls through the free, open-sourced Jitsi video platform.
 - [Lightsensor](https://github.com/Elvincth/capacitor-plugin-lightsensor) - Get the illuminance level on the device.
+- [Native Audio Player](https://github.com/smartcompanion-app/native-audio-player) - Play audio that keeps playing in the background, player is shown in system controls, audio output can be switched between speaker/earpiece
 - [Native settings](https://github.com/RaphaelWoude/capacitor-native-settings) - Open native settings screens.
 - NativeScript
     - [NativeScript Capacitor](https://github.com/NativeScript/capacitor) - Empower Capacitor with native APIs.

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ Independents plugins are listed here.
 - [Intent](https://github.com/IT-MikeS/capacitor-intents) - Supports multiple broadcast receiving of intents, and sending out BroadcastIntents in Android.
 - [Jitsi](https://github.com/calvinckho/capacitor-jitsi-meet) - Make video calls through the free, open-sourced Jitsi video platform.
 - [Lightsensor](https://github.com/Elvincth/capacitor-plugin-lightsensor) - Get the illuminance level on the device.
-- [Native Audio Player](https://github.com/smartcompanion-app/native-audio-player) - Play audio that keeps playing in the background, player is shown in system controls, audio output can be switched between speaker/earpiece
+- [Native Audio Player](https://github.com/smartcompanion-app/native-audio-player) - Play audio that keeps playing in the background, player is shown in system controls, audio output can be switched between speaker/earpiece.
 - [Native settings](https://github.com/RaphaelWoude/capacitor-native-settings) - Open native settings screens.
 - NativeScript
     - [NativeScript Capacitor](https://github.com/NativeScript/capacitor) - Empower Capacitor with native APIs.


### PR DESCRIPTION
Thx @riderx  for maintaining this helpful list of plugins! Would be great if you could add our Native Audio Player plugin. It could be helpful for people who want to play audio that keeps playing in the background, player is shown in system controls, audio output can be switched between speaker/earpiece...