### PR TITLE
Add lazycap to Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -381,6 +381,7 @@ This list will be upgraded soon
 - [Assets](https://github.com/ionic-team/capacitor-assets) - Local Capacitor icon/splash screen resource generation tool.
 - [Tailwind Capacitor](https://github.com/Cap-go/tailwind-capacitor) - Collection of helper plugin for Tailwind, it add safe area class and others utlitilies.
 - [Capacitor safe area simulator](https://chromewebstore.google.com/detail/capacitor-safe-area-simul/ddaaodgcccedhjbjeollookhompnlfhi) - Chrome extension to simulate safe area in the browser, it support Ionic, Knsta UI and Tailwind Capacitor.
+- [lazycap](https://github.com/icarus-itcs/lazycap) - Terminal dashboard for Capacitor development with device management, builds, live reload, debugging, and AI assistant integration via MCP.
 
 ## Learning
 


### PR DESCRIPTION
Hi! I'd like to add [lazycap](https://github.com/icarus-itcs/lazycap) to the Tools section.

**lazycap** is a terminal dashboard for Capacitor development that provides:

- Device management (iOS simulators, Android emulators, physical devices)
- One-key actions for build, sync, run, and open in IDE
- Live reload with external host detection
- 30+ debug/cleanup actions (clear Derived Data, Gradle cache, node_modules, etc.)
- Process monitoring with real-time logs
- AI assistant integration via MCP (Model Context Protocol)
- Firebase Emulator integration
- Plugin system for extensibility

It's open source (MIT + Commons Clause) and built with Go.

Thanks for considering!