### PR TITLE
Add capacitor-thermal-state plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -348,6 +348,7 @@ Independents plugins are listed here.
 - [Capacitor Calendar](https://github.com/ebarooni/capacitor-calendar) - A plugin for interacting with calendar and reminders.
 - [Capacitor voice recorder](https://github.com/tchvu3/capacitor-voice-recorder) - A plugin for simple voice recording.
 - [capacitor-app-attest](https://github.com/ludufre/capacitor-app-attest) - Apple Attest with Ionic Capacitor.
+- [capacitor-thermal-state](https://github.com/isaforge/capacitor-thermal-state) - Monitor device thermal state (overheating detection) on iOS and Android.
 - [capacitor-live-activities](https://github.com/ludufre/capacitor-live-activities) - Capacitor plugin to use Live Activities on iOS 16.2+.
 - [capacitor-lottie-splash-screen](https://github.com/ludufre/capacitor-lottie-splash-screen) - Capacitor plugin to use Lottie animations as splash screen.
 


### PR DESCRIPTION
A new plugin for monitoring device thermal state on iOS and Android.
Supports getState(), addListener() and simulateHeat() for testing.
npm: https://www.npmjs.com/package/capacitor-thermal-state