### PR TITLE
Add PQ Secure Storage to Other plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,7 @@ Independents plugins are listed here.
 - [Navigation bar](https://github.com/hugotomazi/navigation-bar) - Manipulation and control of the navigation bar visibility.
 - [Oauth2](https://github.com/moberwasserlechner/capacitor-oauth2) - Generic OAuth 2 client plugin. It let you configure the OAuth parameters yourself instead of using SDKs.
 - [Playlist](https://github.com/phiamo/capacitor-plugin-playlist) - Native support for audio playlists, background support, and lock screen controls.
+- [PQ Secure Storage](https://github.com/jimcase/capacitor-pq-secure-storage) - Post-quantum signing (ML-DSA) and key encapsulation (ML-KEM) with keys held in the iOS Secure Enclave and the Android Keystore, plus biometric-gated secure storage.
 - [Print](https://github.com/leoruhland/capacitor-print) - Send WebView content to connected printers.
 - [Rate app](https://github.com/Nodonisko/capacitor-rate-app) - Let users rate your app using native rate app dialog for both Android and iOS.
 - [Read sms](https://github.com/Ayush-Rajniwal/cap-read-sms) - Read the user's SMS with their permission.


### PR DESCRIPTION
https://www.npmjs.com/package/capacitor-pq-secure-storage

Post-quantum crypto (ML-DSA FIPS 204, ML-KEM FIPS 203) with the private keys held in the iOS Secure Enclave and the Android Keystore, gated by a biometric per operation. Also does AES-256-GCM at rest and a biometric-gated key-value store, with a software fallback on the web. MIT.

Nothing else in the list covers post-quantum signing, and iOS 26 only just made the Secure Enclave side possible.